### PR TITLE
FlexibleSensorLock stat Dependency and ActiveProbe

### DIFF
--- a/IRTweaks/IRTweaks/IRTweaks.csproj
+++ b/IRTweaks/IRTweaks/IRTweaks.csproj
@@ -86,6 +86,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(BattleTechGameDir)\BattleTech_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
+	 <Reference Include="UnityEngine.ParticleSystemModule">
+      <HintPath>$(BattleTechGameDir)\BattleTech_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Helper\ActorHelper.cs" />

--- a/IRTweaks/IRTweaks/ModConfig.cs
+++ b/IRTweaks/IRTweaks/ModConfig.cs
@@ -38,6 +38,9 @@ namespace IRTweaks
         public class FlexibleSensorLockOptions
         {
             public bool FreeActionWithAbility = false;
+            public bool FreeActionWithStat = false;
+            public string FreeActionStatName = "FreeSensorLock";
+            public bool AlsoAppliesToActiveProbe = false;
         }
 
         public PainToleranceOpts PainTolerance = new PainToleranceOpts();

--- a/IRTweaks/IRTweaks/ModState.cs
+++ b/IRTweaks/IRTweaks/ModState.cs
@@ -9,6 +9,7 @@ namespace IRTweaks {
         public static Dictionary<string, int> PilotCalledShotModifiers = new Dictionary<string, int>();
 
         public static SelectionStateSensorLock SelectionStateSensorLock;
+        public static SelectionStateActiveProbe SelectionStateActiveProbe;
 
         // Tracks an attack sequence that creates an injury
         public static float InjuryResistPenalty = -1f;

--- a/IRTweaks/IRTweaks/Modules/Combat/FlexibleSensorLock.cs
+++ b/IRTweaks/IRTweaks/Modules/Combat/FlexibleSensorLock.cs
@@ -130,7 +130,7 @@ namespace IRTweaks.Modules.Combat {
             __result = false;
         }
 
-        public static void AbstractActor_InitStats_Prefix(AbstractActor __instance)
+        public static void Mech_InitStats_Prefix(AbstractActor __instance)
         {
             if (!__instance.Combat.IsLoadingFromSave && Mod.Config.Combat.FlexibleSensorLock.FreeActionWithStat)
             {

--- a/IRTweaks/IRTweaks/Modules/Combat/FlexibleSensorLock.cs
+++ b/IRTweaks/IRTweaks/Modules/Combat/FlexibleSensorLock.cs
@@ -4,13 +4,14 @@ using Harmony;
 
 namespace IRTweaks.Modules.Combat {
     using System.Linq;
+    using UnityEngine;
 
     public static class FlexibleSensorLock {
 
         public static void SelectionStateSensorLock_CanActorUseThisState_Postfix(SelectionStateSensorLock __instance, AbstractActor actor, ref bool __result) {
             Mod.Log.Trace?.Write("SSSL:CAUTS entered");
 
-            if (PilotHasFreeSensorLockAbility(actor)) {
+            if (ActorHasFreeSensorLock(actor)) {
                 Pilot pilot = actor?.GetPilot();
                 Ability activeAbility = pilot.GetActiveAbility(ActiveAbilityID.SensorLock);
                 bool flag = (activeAbility != null && activeAbility.IsAvailable);
@@ -32,7 +33,7 @@ namespace IRTweaks.Modules.Combat {
             //Mod.Log.Trace?.Write($"  oa:{___owningActor.DisplayName}_{___owningActor.GetPilot().Name} hasFired:{___owningActor.HasFiredThisRound} hasMoved:{___owningActor.HasMovedThisRound} hasActivated:{___owningActor.HasActivatedThisRound}");
 
             // Force the ability to be on cooldown
-            if (PilotHasFreeSensorLockAbility(___owningActor)) {
+            if (ActorHasFreeSensorLock(___owningActor)) {
                 Pilot pilot = ___owningActor.GetPilot();
                 Ability ability = pilot.GetActiveAbility(ActiveAbilityID.SensorLock);
                 Mod.Log.Debug?.Write($"  On sensor lock complete, cooldown is:{ability.CurrentCooldown}");
@@ -57,7 +58,7 @@ namespace IRTweaks.Modules.Combat {
         }
 
         public static bool OrderSequence_OnComplete_Prefix(OrderSequence __instance, AbstractActor ___owningActor) {
-            if (__instance is SensorLockSequence && PilotHasFreeSensorLockAbility(___owningActor)) {
+            if ((__instance is SensorLockSequence || (__instance is ActiveProbeSequence && Mod.Config.Combat.FlexibleSensorLock.AlsoAppliesToActiveProbe) ) && ActorHasFreeSensorLock(___owningActor)) {
                 Mod.Log.Trace?.Write($"OS:OC entered, cm:{__instance.ConsumesMovement} cf:{__instance.ConsumesFiring}");
                 Mod.Log.Trace?.Write($"    oa:{___owningActor.DisplayName}_{___owningActor.GetPilot().Name} hasFired:{___owningActor.HasFiredThisRound} hasMoved:{___owningActor.HasMovedThisRound} hasActivated:{___owningActor.HasActivatedThisRound}");
                 Mod.Log.Trace?.Write($"    ca:{__instance.ConsumesActivation} fae:{__instance.ForceActivationEnd}");
@@ -83,40 +84,36 @@ namespace IRTweaks.Modules.Combat {
         }
 
         public static void OrderSequence_ConsumesActivation_Postfix(OrderSequence __instance, ref bool __result, AbstractActor ___owningActor) {
-            if (__instance is SensorLockSequence)
+            if (__instance is SensorLockSequence || (__instance is ActiveProbeSequence && Mod.Config.Combat.FlexibleSensorLock.AlsoAppliesToActiveProbe))
             {
                 __result = true;
-                if (!Mod.Config.Combat.FlexibleSensorLock.FreeActionWithAbility)
+                if (ActorHasFreeSensorLock(___owningActor))
                 {
-                    Mod.Log.Debug?.Write(" OrderSequence_ConsumesActivation_Postfix - Sensor Lock is always a free ability, setting __result to false...");
-                    // If we're in this method and haven't set sensor lock to be free with an ability, FlexibleSensorLock has been enabled and patched, so we always return false.
                     __result = false;
-                }
-                else
-                {
-                    // Check if the pilot has the associated ability ID, and return true if so...
-                    Mod.Log.Debug?.Write($" OrderSequence_ConsumesActivation_Postfix - Sensor Lock is paired with ability [{Mod.Config.Abilities.FlexibleSensorLockId}], checking pilot...");
-                    if (PilotHasFreeSensorLockAbility(___owningActor?.GetPilot()))
-                    {
-                        Mod.Log.Debug?.Write($" OrderSequence_ConsumesActivation_Postfix - Sensor Lock paired ability [{Mod.Config.Abilities.FlexibleSensorLockId}] found, setting true...");
-                        __result = false;
-                    }
                 }
                 Mod.Log.Debug?.Write($" OrderSequence_ConsumesActivation_Postfix - returning [{__result}].");
             }
         }
 
-        private static bool PilotHasFreeSensorLockAbility(AbstractActor actor)
+        private static bool ActorHasFreeSensorLock(AbstractActor actor)
         {
-            return actor != null && PilotHasFreeSensorLockAbility(actor.GetPilot());
+            if (actor == null)
+                return false;
+
+            if (!Mod.Config.Combat.FlexibleSensorLock.FreeActionWithStat && !Mod.Config.Combat.FlexibleSensorLock.FreeActionWithAbility)
+                return true;
+
+            if (Mod.Config.Combat.FlexibleSensorLock.FreeActionWithStat && actor.StatCollection.GetValue<bool>(Mod.Config.Combat.FlexibleSensorLock.FreeActionStatName))
+                return true;
+
+            Pilot pilot = actor.GetPilot();
+            Mod.Log.Debug?.Write($"pilot = [{pilot}]\r\n"
+                          + $"abilities = [{string.Join(",", pilot?.Abilities.Select(ability => ability.Def.Id))}]");
+            if (Mod.Config.Combat.FlexibleSensorLock.FreeActionWithAbility && (pilot?.Abilities?.Exists(ability => ability.Def.Id == Mod.Config.Abilities.FlexibleSensorLockId) ?? false))
+                return true;
+            return false;
         }
 
-        private static bool PilotHasFreeSensorLockAbility(Pilot pilot)
-        {
-            Mod.Log.Debug?.Write($"pilot = [{pilot}]\r\n" 
-                          + $"abilities = [{string.Join(",", pilot?.Abilities.Select(ability => ability.Def.Id))}]");
-            return Mod.Config.Combat.FlexibleSensorLock.FreeActionWithAbility == false || (pilot?.Abilities?.Exists(ability => ability.Def.Id == Mod.Config.Abilities.FlexibleSensorLockId) ?? false);
-        }
 
         public static bool AIUtil_EvaluateSensorLockQuality_Prefix(ref bool __result, AbstractActor movingUnit, ICombatant target, out float quality) {
             AbstractActor abstractActor = target as AbstractActor;
@@ -131,6 +128,71 @@ namespace IRTweaks.Modules.Combat {
 
         public static void Returns_False_Postfix(ref bool __result) {
             __result = false;
+        }
+
+        public static void AbstractActor_InitStats_Prefix(AbstractActor __instance)
+        {
+            if (!__instance.Combat.IsLoadingFromSave && Mod.Config.Combat.FlexibleSensorLock.FreeActionWithStat)
+            {
+                __instance.StatCollection.AddStatistic(Mod.Config.Combat.FlexibleSensorLock.FreeActionStatName, false);
+            }
+        }
+
+        public static void SelectionStateActiveProbe_CanActorUseThisState_Postfix(SelectionStateActiveProbe __instance, AbstractActor actor, ref bool __result)
+        {
+            Mod.Log.Trace?.Write("SSAP:CAUTS entered");
+
+            if (ActorHasFreeSensorLock(actor))
+            {
+                Ability activeAbility = actor.ComponentAbilities.Find((Ability x) => x.Def.Targeting == AbilityDef.TargetingType.ActiveProbe);
+                bool flag = (activeAbility != null && activeAbility.IsAvailable);
+                Mod.Log.Debug?.Write($"  Pilot has sensorLock:{activeAbility} and abilityIsAvailable:{activeAbility.IsAvailable}");
+                __result = flag;
+            }
+        }
+
+        public static void SelectionStateActiveProbe_CreateFiringOrders_Postfix(SelectionStateActiveProbe __instance, string button)
+        {
+            Mod.Log.Trace?.Write("SSSL:CFO entered");
+
+            if (button == "BTN_FireConfirm" && __instance.HasTarget)
+            {
+                ModState.SelectionStateActiveProbe = __instance;
+            }
+        }
+
+        public static bool ActiveProbeSequence_CompleteOrders_Prefix(ActiveProbeSequence __instance, AbstractActor ___owningActor, ParticleSystem ___probeParticles)
+        {
+            Mod.Log.Trace?.Write("SLS:CO entered, aborting invocation");
+            //Mod.Log.Trace?.Write($"  oa:{___owningActor.DisplayName}_{___owningActor.GetPilot().Name} hasFired:{___owningActor.HasFiredThisRound} hasMoved:{___owningActor.HasMovedThisRound} hasActivated:{___owningActor.HasActivatedThisRound}");
+
+            // Force the ability to be on cooldown
+            if (ActorHasFreeSensorLock(___owningActor))
+            {
+                CombatGameState ___Combat = Traverse.Create(__instance).Property("Combat").GetValue<CombatGameState>();
+                if (___probeParticles != null)
+                {
+                    ___probeParticles.Stop(true);
+                    ___Combat.DataManager.PoolGameObject(___Combat.Constants.VFXNames.active_probe_effect, ___probeParticles.gameObject);
+                }
+                WwiseManager.PostEvent(AudioEventList_activeProbe.activeProbe_stop, WwiseManager.GlobalAudioObject, null, null);
+
+                Mod.Log.Debug?.Write($"  Clearing all sequences");
+
+                if (ModState.SelectionStateActiveProbe != null)
+                {
+                    Mod.Log.Debug?.Write($"  Calling clearTargetedActor");
+                    Traverse traverse = Traverse.Create(ModState.SelectionStateActiveProbe).Method("RefreshPossibleTargets");
+                    traverse.GetValue();
+
+                    //State.SelectionStateSensorLock.BackOut();
+
+                    ModState.SelectionStateActiveProbe = null;
+                }
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/IRTweaks/IRTweaks/Modules/CombatModule.cs
+++ b/IRTweaks/IRTweaks/Modules/CombatModule.cs
@@ -77,6 +77,39 @@ namespace IRTweaks.Modules.Combat
                         MethodInfo aiu_eslq = AccessTools.Method(typeof(AIUtil), "EvaluateSensorLockQuality");
                         HarmonyMethod fsl_aiu_eslq_pre = new HarmonyMethod(typeof(FlexibleSensorLock), "AIUtil_EvaluateSensorLockQuality_Prefix");
                         harmony.Patch(aiu_eslq, fsl_aiu_eslq_pre, null, null);
+
+                        MethodInfo abact_ins = AccessTools.Method(typeof(AbstractActor), "InitStats");
+                        HarmonyMethod fsl_abact_ins = new HarmonyMethod(typeof(FlexibleSensorLock), "AbstractActor_InitStats_Prefix");
+                        harmony.Patch(abact_ins, fsl_abact_ins, null, null);
+
+                        if (Mod.Config.Combat.FlexibleSensorLock.AlsoAppliesToActiveProbe)
+                        {
+                            // sel state
+                            PropertyInfo ssap_cf = AccessTools.Property(typeof(SelectionStateActiveProbe), "ConsumesFiring");
+                            harmony.Patch(ssap_cf.GetGetMethod(false), null, slc_r_f_post, null);
+
+                            PropertyInfo ssap_cm = AccessTools.Property(typeof(SelectionStateActiveProbe), "ConsumesMovement");
+                            harmony.Patch(ssap_cf.GetGetMethod(false), null, slc_r_f_post, null);
+
+                            MethodInfo ssap_cauts = AccessTools.Method(typeof(SelectionStateActiveProbe), "CanActorUseThisState");
+                            HarmonyMethod fsl_ssap_cauts_post = new HarmonyMethod(typeof(FlexibleSensorLock), "SelectionStateActiveProbe_CanActorUseThisState_Postfix");
+                            harmony.Patch(ssap_cauts, null, fsl_ssap_cauts_post, null);
+
+                            MethodInfo ssap_cfo = AccessTools.Method(typeof(SelectionStateActiveProbe), "CreateFiringOrders");
+                            HarmonyMethod fsl_ssap_cfo_post = new HarmonyMethod(typeof(FlexibleSensorLock), "SelectionStateActiveProbe_CreateFiringOrders_Postfix");
+                            harmony.Patch(ssap_cfo, null, fsl_ssap_cfo_post, null);
+
+                            //ActiveProbeSequence CompleteOrders
+                            MethodInfo aps_co = AccessTools.Method(typeof(ActiveProbeSequence), "CompleteOrders");
+                            HarmonyMethod fsl_aps_co_pre = new HarmonyMethod(typeof(FlexibleSensorLock), "ActiveProbeSequence_CompleteOrders_Prefix");
+                            harmony.Patch(aps_co, fsl_aps_co_pre, null, null);
+
+                            PropertyInfo aps_cf = AccessTools.Property(typeof(ActiveProbeSequence), "ConsumesFiring");
+                            harmony.Patch(aps_cf.GetGetMethod(false), null, slc_r_f_post, null);
+
+                            PropertyInfo aps_cm = AccessTools.Property(typeof(ActiveProbeSequence), "ConsumesMovement");
+                            harmony.Patch(aps_cm.GetGetMethod(false), null, slc_r_f_post, null);
+                        }
                     }
 
                     if (Mod.Config.Fixes.PainTolerance)

--- a/IRTweaks/IRTweaks/Modules/CombatModule.cs
+++ b/IRTweaks/IRTweaks/Modules/CombatModule.cs
@@ -78,9 +78,8 @@ namespace IRTweaks.Modules.Combat
                         HarmonyMethod fsl_aiu_eslq_pre = new HarmonyMethod(typeof(FlexibleSensorLock), "AIUtil_EvaluateSensorLockQuality_Prefix");
                         harmony.Patch(aiu_eslq, fsl_aiu_eslq_pre, null, null);
 
-                        MethodInfo abact_ins = AccessTools.Method(typeof(AbstractActor), "InitStats");
-                        HarmonyMethod fsl_abact_ins = new HarmonyMethod(typeof(FlexibleSensorLock), "AbstractActor_InitStats_Prefix");
-                        harmony.Patch(abact_ins, fsl_abact_ins, null, null);
+                        HarmonyMethod fsl_abact_ins = new HarmonyMethod(typeof(FlexibleSensorLock), "Mech_InitStats_Prefix");
+                        harmony.Patch(AccessTools.Method(typeof(Mech), "InitStats"), fsl_abact_ins, null, null);
 
                         if (Mod.Config.Combat.FlexibleSensorLock.AlsoAppliesToActiveProbe)
                         {


### PR DESCRIPTION
FlexibleSensorLock can now depend on an AbstractActor Statistic, for example allowing only Mechs equipped with Active Probe a free Sensor Lock.
Additionally Active Probe Ping can now be set to be a free action with the same requirements as Sensor Lock (Issue: #3 )